### PR TITLE
Enable use of property music.skip for skipping

### DIFF
--- a/music-maven-plugin/src/main/java/software/xdev/maven/music/MusicMojo.java
+++ b/music-maven-plugin/src/main/java/software/xdev/maven/music/MusicMojo.java
@@ -39,7 +39,7 @@ public class MusicMojo extends AbstractMojo
 {
 	protected static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
 	
-	@Parameter
+	@Parameter(property="music.skip")
 	protected boolean skip;
 	
 	@Parameter


### PR DESCRIPTION
Did not see myself proposing a contribution to this plugin, but here we are 😆 

With `@Parameter(property="music.skip")` for the `skip`-parameter in `MusicMojo`, this enables the troller to subtly disable accidentally blasting the music in the office space while waiting for the trollees to be trolled, while avoiding being self-trolled.

E.g. by using the command:
```sh
mvn install -Dmusic.skip
```

or even set it globally with the `MAVEN_OPTS` environment variable:
```
MAVEN_OPTS="-Dmusic.skip=true"
```


Running `mvn help:describe -Dplugin=music -Dgoal=music -Ddetail` in a project with the plugin configured will show the following addition to the `skip` parameter:

```diff
  [INFO] --- help:3.5.1:describe (default-cli) @ signering ---
  [INFO] Mojo: 'music:music'
  music:music
    Description: (no description available)
    Implementation: software.xdev.maven.music.MusicMojo
    Language: java
    Bound to phase: validate

    Available parameters:

      background
        Plays the music in the background (non-blocking) If this set to false,
        repeat will be forcefully set to false
    (...)
      skip
>       User property: music.skip
        (no description available)
```